### PR TITLE
output VM IP

### DIFF
--- a/environments/common/outputs.auto.tf
+++ b/environments/common/outputs.auto.tf
@@ -1,0 +1,4 @@
+// run this command to check the VM is up and running
+output "test_command" {
+  value = format("ping -c 1 %s", module.vm.external_ip)
+}

--- a/environments/master/outputs.auto.tf
+++ b/environments/master/outputs.auto.tf
@@ -1,0 +1,1 @@
+../common/outputs.auto.tf

--- a/environments/staging/outputs.auto.tf
+++ b/environments/staging/outputs.auto.tf
@@ -1,0 +1,1 @@
+../common/outputs.auto.tf

--- a/modules/vm/outputs.tf
+++ b/modules/vm/outputs.tf
@@ -1,0 +1,3 @@
+output "external_ip" {
+  value = google_compute_instance.default.network_interface.0.access_config.0.nat_ip
+}


### PR DESCRIPTION
In Terraform _apply_ step, output command that validates the VM is running and an IP connected to the internet.

![Screen Shot 2020-06-17 at 1 27 26 PM](https://user-images.githubusercontent.com/9662521/84947298-d1d5ea00-b09e-11ea-9cf8-4dd66ed2ff31.png)
